### PR TITLE
Ported `waveform_features_utils` to `features.py`

### DIFF
--- a/spikefeatures/features.py
+++ b/spikefeatures/features.py
@@ -1,1 +1,201 @@
-# port waveform_features_utils.py here
+"""
+Functions based on
+https://github.com/AllenInstitute/ecephys_spike_sorting/blob/master/ecephys_spike_sorting/modules/mean_waveforms/waveform_metrics.py
+15/04/2020
+"""
+
+import numpy as np
+from scipy.stats import linregress
+import pandas as pd
+
+all_1D_features = ['peak_to_valley', 'halfwidth', 'peak_trough_ratio',
+                   'repolarization_slope', 'recovery_slope']
+
+
+def calculate_features(waveforms, sampling_frequency, feature_names=None,
+                       recovery_slope_window=0.7):
+    """ Calculate features for all waveforms
+
+    Parameters
+    ----------
+    waveforms  : numpy.ndarray (num_waveforms x num_samples)
+        waveforms to compute features for
+    sampling_frequency  : float
+        rate at which the waveforms are sampled (Hz)
+    feature_names : list or None (if None, compute all)
+        features to compute
+    recovery_slope_window : float
+        windowlength after peak wherein recovery slope is computed
+
+    Returns
+    -------
+    metrics : pandas.DataFrame  (num_waveforms x num_metrics)
+        one column for each metric
+        one row per waveforms
+
+    """
+    metrics = pd.DataFrame()
+
+    if feature_names is None:
+        feature_names = all_1D_features
+    else:
+        for name in feature_names:
+            assert name in all_1D_features, f'{name} not in {all_1D_features}'
+
+    if 'peak_to_valley' in feature_names:
+        metrics['peak_to_valley'] = peak_to_valley(waveforms=waveforms,
+                                                   sampling_frequency=sampling_frequency)
+    if 'peak_trough_ratio' in feature_names:
+        metrics['peak_trough_ratio'] = peak_trough_ratio(waveforms=waveforms)
+
+    if 'halfwidth' in feature_names:
+        metrics['halfwidth'] = halfwidth(waveforms=waveforms,
+                                         sampling_frequency=sampling_frequency)
+
+    if 'repolarization_slope' in feature_names:
+        metrics['repolarization_slope'] = repolarization_slope(
+            waveforms=waveforms,
+            sampling_frequency=sampling_frequency,
+        )
+
+    if 'recovery_slope' in feature_names:
+        metrics['recovery_slope'] = recovery_slope(
+            waveforms=waveforms,
+            sampling_frequency=sampling_frequency,
+            window=recovery_slope_window,
+        )
+    return metrics
+
+
+def peak_to_valley(waveforms, sampling_frequency):
+    """
+
+    :param waveforms:
+    :param sampling_frequency:
+    :return:
+    """
+    trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
+    ptv = (peak_idx - trough_idx) * (1/sampling_frequency)
+    return ptv
+
+
+def peak_trough_ratio(waveforms):
+    """ peak height / trough depth
+
+    :param waveforms:
+    :return:
+    """
+    trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
+    ptratio = np.empty(trough_idx.shape[0])
+    for i, (thidx, pkidx) in enumerate(zip(trough_idx, peak_idx)):
+        ptratio[i] = waveforms[i, pkidx] / waveforms[i, thidx]
+    return ptratio
+
+
+def halfwidth(waveforms, sampling_frequency, return_idx=False):
+    """ Width of the peak at its half ampltude heigth
+
+    :param waveforms:
+    :param sampling_frequency:
+    :return:
+    """
+    trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
+    hw = np.empty(waveforms.shape[0])
+    cross_pre_pk = np.empty(waveforms.shape[0], dtype=np.int)
+    cross_post_pk = np.empty(waveforms.shape[0], dtype=np.int)
+
+    for i in range(waveforms.shape[0]):
+        peak_val = waveforms[i, peak_idx[i]]
+        threshold = 0.5 * peak_val
+
+        cpre_idx = np.where(waveforms[i, :peak_idx[i]] < threshold)[0]
+        cpost_idx = np.where(waveforms[i, peak_idx[i]:] < threshold)[0]
+
+        if len(cpre_idx) == 0 or len(cpost_idx) == 0:
+            continue
+
+        cross_pre_pk[i] = cpre_idx[-1] + 1  # last occurence of waveform lower than thr, before peak
+        cross_post_pk[i] = cpost_idx[0] - 1 + peak_idx[i]  # first occurence of waveform lower than peak, after peak
+        hw[i] = (cross_post_pk[i] - cross_pre_pk[i] + peak_idx[i]) * (1/sampling_frequency)
+
+    if not return_idx:
+        return hw
+    else:
+        return hw, cross_pre_pk, cross_post_pk
+
+
+def repolarization_slope(waveforms, sampling_frequency, return_idx=False):
+    """
+
+    :param waveforms:
+    :param sampling_frequency:
+    :return:
+    """
+    trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
+
+    rslope = np.empty(waveforms.shape[0])
+    return_to_base_idx = np.empty(waveforms.shape[0], dtype=np.int)
+
+    time = np.arange(0, waveforms.shape[1]) * (1/sampling_frequency)  # in s
+    for i in range(waveforms.shape[0]):
+        rtrn_idx = np.where(waveforms[i, trough_idx[i]:] >= 0)[0]
+        if len(rtrn_idx) == 0:
+            continue
+
+        return_to_base_idx[i] = rtrn_idx[0] + trough_idx[i]  # first time after  trough, where waveform is at baseline
+        rslope[i] = linregress(time[trough_idx[i]:return_to_base_idx[i]],
+                               waveforms[i, trough_idx[i]: return_to_base_idx[i]])[0]
+
+    if not return_idx:
+        return rslope
+    else:
+        return rslope, return_to_base_idx
+
+
+def recovery_slope(waveforms, sampling_frequency, window):
+    """
+
+    Parameters
+    ----------
+    waveforms : numpy.ndarray [n_template x n_samples]
+    fs : samplerate in Hz
+    sampling_frequency : duration after peak to include for regression
+
+    Returns
+    -------
+
+    """
+    _, peak_idx = _get_trough_and_peak_idx(waveforms)
+    rslope = np.empty(waveforms.shape[0])
+    time = np.arange(0, waveforms.shape[1]) * (1/sampling_frequency)  # in s
+
+    for i in range(waveforms.shape[0]):
+        max_idx = int(peak_idx[i] + ((window/1000)*sampling_frequency))
+        max_idx = np.min([max_idx, waveforms.shape[1]])
+        slope = _get_slope(time[peak_idx[i]:max_idx], waveforms[i, peak_idx[i]:max_idx])
+        rslope[i] = slope[0]
+    return rslope
+
+
+def _get_slope(time, waveform):
+    """
+
+    :param time:
+    :param waveform:
+    :return:
+    """
+    slope = linregress(time, waveform)
+    return slope
+
+
+def _get_trough_and_peak_idx(waveform):
+    trough_idx = np.argmin(waveform, axis=1)
+    peak_idx = np.empty(trough_idx.shape, dtype=int)
+    for i, tridx in enumerate(trough_idx):
+        if tridx == waveform.shape[1]-1:
+            continue
+        idx = np.argmax(waveform[i, tridx:])
+        peak_idx[i] = idx + tridx
+    return trough_idx, peak_idx
+
+

--- a/spikefeatures/features.py
+++ b/spikefeatures/features.py
@@ -68,11 +68,19 @@ def calculate_features(waveforms, sampling_frequency, feature_names=None,
 
 
 def peak_to_valley(waveforms, sampling_frequency):
-    """ time in s between throug and peak
+    """ Distance between trough and peak
 
-    :param waveforms: numpy.ndarray (num_waveforms x num_samples)
-    :param sampling_frequency: rate at which the waveforms are sampled (Hz)
-    :return: peak_to_valley; np.ndarray (num_waveforms)
+    Parameters
+    ----------
+    waveforms  : numpy.ndarray (num_waveforms x num_samples)
+        waveforms to compute feature for
+    sampling_frequency  : float
+        rate at which the waveforms are sampled (Hz)
+
+    Returns
+    -------
+    peak_to_valley; np.ndarray (num_waveforms)
+
     """
     trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
     ptv = (peak_idx - trough_idx) * (1/sampling_frequency)
@@ -80,10 +88,21 @@ def peak_to_valley(waveforms, sampling_frequency):
 
 
 def peak_trough_ratio(waveforms):
-    """ waveform peak height / trough depth
+    """ Ratio peak heigth and trough depth
 
-    :param waveforms: numpy.ndarray (num_waveforms x num_samples)
-    :return: peak_trough_ratio; np.ndarray (num_waveforms)
+    Assumes baseline is 0
+
+    Parameters
+    ----------
+    waveforms  : numpy.ndarray (num_waveforms x num_samples)
+        waveforms to compute feature for
+
+    Returns
+    -------
+
+    np.ndarray (num_waveforms)
+        Peak to trough ratio
+
     """
     trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
     ptratio = np.empty(trough_idx.shape[0])
@@ -93,12 +112,28 @@ def peak_trough_ratio(waveforms):
 
 
 def halfwidth(waveforms, sampling_frequency, return_idx=False):
-    """ Width of the waveform peak at its half ampltude heigth
+    """
+    Width of waveform at its half of amplitude
 
-    :param return_idx: bool, if true return halfwidth, index of crossing threhold pre peak, index of crossing post peak
-    :param waveforms: numpy.ndarray (num_waveforms x num_samples)
-    :param sampling_frequency: rate at which the waveforms are sampled (Hz)
-    :return: peak_to_valley; np.ndarray (num_waveforms)
+    Computes the width of the waveform peak at half it's height
+
+    Parameters
+    ----------
+    waveforms  : numpy.ndarray (num_waveforms x num_samples)
+        waveforms to compute features for
+    sampling_frequency  : float
+        rate at which the waveforms are sampled (Hz)
+    return_idx : bool
+        if true, also returns index of threshold crossing before and
+        index of threshold crossing after peak
+
+    Returns
+    -------
+
+    np.ndarray or (np.ndarray, np.ndarray, np.ndarray)
+        Halfwidth of the waveforms or (Halfwidth of the waveforms,
+        index_cross_pre_peak, index_cross_post_peak)
+
     """
     trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
     hw = np.empty(waveforms.shape[0])
@@ -126,12 +161,32 @@ def halfwidth(waveforms, sampling_frequency, return_idx=False):
 
 
 def repolarization_slope(waveforms, sampling_frequency, return_idx=False):
-    """ waveform slope between trough and first crossing of baseline thereafter
+    """
+    Return slope of repolarization period between trough and baseline
 
-    :param return_idx: bool, if true return halfwidth, index of crossing baseline after trough
-    :param waveforms: numpy.ndarray (num_waveforms x num_samples)
-    :param sampling_frequency: rate at which the waveforms are sampled (Hz)
-    :return: repolarization slope; np.ndarray (num_waveforms)
+    After reaching it's maxumum polarization, the neuron potential will
+    recover. The repolarization slope is defined as the dV/dT of the action potential
+    between trough and baseline.
+
+    Optionally the function returns also the indices per waveform where the
+    potential crosses baseline.
+
+    Parameters
+    ----------
+    waveforms  : numpy.ndarray (num_waveforms x num_samples)
+        waveforms to compute features for
+    sampling_frequency  : float
+        rate at which the waveforms are sampled (Hz)
+    return_idx : bool
+        if true, also returns index of threshold crossing before and
+        index of threshold crossing after peak
+
+    Returns
+    -------
+
+    np.ndarray or (np.ndarray, np.ndarray, np.ndarray)
+        Halfwidth of the waveforms or (Halfwidth of the waveforms,
+        index_cross_pre_peak, index_cross_post_peak)
     """
     trough_idx, peak_idx = _get_trough_and_peak_idx(waveforms)
 
@@ -155,12 +210,32 @@ def repolarization_slope(waveforms, sampling_frequency, return_idx=False):
 
 
 def recovery_slope(waveforms, sampling_frequency, window):
-    """ slope of waveform after peak, within specified window
+    """
+    Return the recovery slope of input waveforms. After repolarization,
+    the neuron hyperpolarizes untill it peaks. The recovery slope is the
+    slope of the actiopotential after the peak, returning to the baseline
+    in dV/dT. The slope is computed within a user-defined window after
+    the peak.
 
-    :param waveforms: numpy.ndarray (num_waveforms x num_samples)
-    :param sampling_frequency: rate at which the waveforms are sampled (Hz)
-    :param window: windowlength in ms after peak wherein recovery slope is computed
-    :return: peak_to_valley; np.ndarray (num_waveforms)
+    Takes a numpy array of waveforms and returns an array with
+    recovery slopes per waveform.
+
+    Parameters
+    ----------
+    waveforms  : numpy.ndarray (num_waveforms x num_samples)
+        waveforms to compute features for
+    sampling_frequency  : float
+        rate at which the waveforms are sampled (Hz)
+    window : float
+        length after peak wherein to compyte recovery slope (ms)
+
+
+    Returns
+    -------
+
+    np.ndarray or (np.ndarray, np.ndarray, np.ndarray)
+        Halfwidth of the waveforms or (Halfwidth of the waveforms,
+        index_cross_pre_peak, index_cross_post_peak)
     """
     _, peak_idx = _get_trough_and_peak_idx(waveforms)
     rslope = np.empty(waveforms.shape[0])
@@ -175,21 +250,19 @@ def recovery_slope(waveforms, sampling_frequency, window):
 
 
 def _get_slope(x, y):
-    """ slope of x and y data
-
-    :param x: np.ndarray (n_samples)
-    :param y: np.ndarray (n_samples)
-    :return: scipy.linregress output (slope, intercept, rvalue, pvalue, stderr)
+    """
+    Retrun the slope of x and y data, using scipy.signal.linregress
     """
     slope = linregress(x, y)
     return slope
 
 
 def _get_trough_and_peak_idx(waveform):
-    """ detect trough and peak in waveform, peak always after trough
+    """
+    Return the indices into the input waveforms of the detected troughs (minimum of waveform)
+    and peaks (maximum of waveform, after trough).
 
-    :param waveform: np.ndarray (num_samples)
-    :return: index_of_trough, index_of_peak
+    Assumes negative troughs and positive peaks
     """
     trough_idx = np.argmin(waveform, axis=1)
     peak_idx = np.empty(trough_idx.shape, dtype=int)


### PR DESCRIPTION
calculate_features is a wrapper for other methods in module

repolarization slope is now computed between trough and baseline

some functions have the keyword 'return_idx', they will return the idx wherefrom the metric is computed (used for visualization)

docstring and names need to be revised